### PR TITLE
VIH-11238 - correct IP format

### DIFF
--- a/renew_sas.ps1
+++ b/renew_sas.ps1
@@ -139,7 +139,7 @@ try {
 
   if($bypass_akv_network){
     $ip = Invoke-RestMethod -Uri api.ipify.org
-    Write-Output "Bypass required, add rule for $ip in $key_vault_name"
+    Write-Output "Bypass required, add rule for $ip/32 in $key_vault_name"
     Add-AzKeyVaultNetworkRule -IpAddressRange "$ip/32" -VaultName $key_vault_name
   }
 
@@ -180,6 +180,6 @@ catch {
 }
 
 if($bypass_akv_network){
-  Write-Output "Removing rule for $ip in $key_vault_name"
+  Write-Output "Removing rule for $ip/32 in $key_vault_name"
   Remove-AzKeyVaultNetworkRule -IpAddressRange "$ip/32" -VaultName $key_vault_name
 }

--- a/renew_sas.ps1
+++ b/renew_sas.ps1
@@ -131,7 +131,7 @@ try {
   #Log in with MI
   Write-Output "Connecting with MI..."
   if($umi_client_id -ne ""){
-    Write-Host "Using User-managed identity"
+    Write-Output "Using User-managed identity"
     Connect-AzAccount -Identity -accountId $umi_client_id
   } else {
     Connect-AzAccount -Identity
@@ -139,8 +139,8 @@ try {
 
   if($bypass_akv_network){
     $ip = Invoke-RestMethod -Uri api.ipify.org
-    Write-host "Bypass required, add rule for $ip in $key_vault_name"
-    Add-AzKeyVaultNetworkRule -IpAddressRange $ip -VaultName $key_vault_name
+    Write-Output "Bypass required, add rule for $ip in $key_vault_name"
+    Add-AzKeyVaultNetworkRule -IpAddressRange "$ip/32" -VaultName $key_vault_name
   }
 
   # Get secret
@@ -180,6 +180,6 @@ catch {
 }
 
 if($bypass_akv_network){
-  Write-host "Removing rule for $ip in $key_vault_name"
-  Remove-AzKeyVaultNetworkRule -IpAddressRange $ip -VaultName $key_vault_name
+  Write-Output "Removing rule for $ip in $key_vault_name"
+  Remove-AzKeyVaultNetworkRule -IpAddressRange "$ip/32" -VaultName $key_vault_name
 }


### PR DESCRIPTION
### Jira link

See [VIH-11238](https://tools.hmcts.net/jira/browse/VIH-11238)

### Change description

Original code was not removing the automation account IP address from the Key Vault firewall because it was not in the correct "/32" format. This change corrects that.

### Testing done



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
